### PR TITLE
Add a systemd service file

### DIFF
--- a/contrib/solaredge-exporter.service
+++ b/contrib/solaredge-exporter.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SolarEdge Prometheus exporter: export ModBus TCP stats gathered from Solaredge inverters to Prometheus
+
+[Service]
+User=solaredge-exporter
+WorkingDirectory=~
+ExecStart=/path/to/solaredge-exporter
+PrivateTmp=yes
+NoNewPrivileges=yes
+Before=prometheus.service
+Wants=prometheus.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a systemd service file. This file assumes the existence of a solaredge-exporter user, with a writeable homedirectory for the log file.

I'm pretty sure additional hardening of this service file is possible.