### PR TITLE
Add parameter for modbus client ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .idea/*
 !.idea/runConfigurations/
 SolarEdge-Exporter.log
+.env

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,7 @@
 /*
-
 MIT License
 
-Copyright (c) 2019 David Suarez
+# Copyright (c) 2019 David Suarez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +20,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
 */
 package config
 
@@ -35,11 +33,13 @@ func InitConfig() {
 	viper.AddConfigPath("$HOME/.solaredge-exporter")
 	viper.SetDefault("SolarEdge.InverterAddress", "")
 	viper.SetDefault("SolarEdge.InverterPort", 0)
+	viper.SetDefault("SolarEdge.ClientId", 1)
 	viper.SetDefault("Exporter.Interval", 5)
 	viper.SetDefault("Exporter.ListenAddress", "")
 	viper.SetDefault("Exporter.ListenPort", 2112)
 	viper.BindEnv("SolarEdge.InverterAddress", "INVERTER_ADDRESS")
 	viper.BindEnv("SolarEdge.InverterPort", "INVERTER_PORT")
+	viper.BindEnv("SolarEdge.ClientId", "INVERTER_CLIENT_ID")
 	viper.BindEnv("Exporter.Interval", "EXPORTER_INTERVAL")
 	viper.BindEnv("Exporter.ListenAddress", "EXPORTER_ADDRESS")
 	viper.BindEnv("Exporter.ListenPort", "EXPORTER_PORT")

--- a/main.go
+++ b/main.go
@@ -1,8 +1,7 @@
 /*
-
 MIT License
 
-Copyright (c) 2019 David Suarez
+# Copyright (c) 2019 David Suarez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +20,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
 */
 package main
 
@@ -30,17 +28,18 @@ import (
 	"SolarEdge-Exporter/exporter"
 	"SolarEdge-Exporter/solaredge"
 	"fmt"
-	"github.com/goburrow/modbus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 	"io"
 	"math"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/goburrow/modbus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 func main() {
@@ -65,6 +64,7 @@ func main() {
 	log.Info().Msgf("Configured Inverter Port: %d", viper.GetInt("SolarEdge.InverterPort"))
 	log.Info().Msgf("Configured Listen Address: %s", viper.GetString("Exporter.ListenAddress"))
 	log.Info().Msgf("Configured Listen Port: %d", viper.GetInt("Exporter.ListenPort"))
+	log.Info().Msgf("Configured Client ID: %x", byte(viper.GetInt("SolarEdge.ClientId")))
 
 	// Start Data Collection
 	// TODO: Add a cancellation context on SIGINT to cleanly close the connection
@@ -88,7 +88,7 @@ func runCollection() {
 			viper.GetString("SolarEdge.InverterAddress"),
 			viper.GetInt("SolarEdge.InverterPort")))
 	handler.Timeout = 10 * time.Second
-	handler.SlaveId = 0x01
+	handler.SlaveId = byte(viper.GetInt("SolarEdge.ClientId"))
 	err := handler.Connect()
 	if err != nil {
 		log.Error().Msgf("Error connecting to Inverter: %s", err.Error())


### PR DESCRIPTION
The SolarEdge inverter makes use of the client ID configured for the third-party modbus. This ID doesn't have to be 0x01, e.g. if the modbus is used by other devices like an accu which was configured differently. This PR adds the configuration parameter `SolarEdge.ClientId`, which can be set using the environment variable `INVERTER_CLIENT_ID` to set the modbus client ID of the inverter. The default value is 0x01, so the change is backward compatible.