### PR TITLE
Fix SonarCloud findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
     name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: wangyoucao577/go-release-action@v1.53
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: wangyoucao577/go-release-action@481a2c1a0f1be199722e3e9b74d7199acafc30a8 # v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goversion: "1.26"
@@ -20,8 +20,8 @@ jobs:
     name: release linux/arm64
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: wangyoucao577/go-release-action@v1.53
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: wangyoucao577/go-release-action@481a2c1a0f1be199722e3e9b74d7199acafc30a8 # v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goversion: "1.26"
@@ -32,8 +32,8 @@ jobs:
     name: release linux/macos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: wangyoucao577/go-release-action@v1.53
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: wangyoucao577/go-release-action@481a2c1a0f1be199722e3e9b74d7199acafc30a8 # v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goversion: "1.26"
@@ -44,8 +44,8 @@ jobs:
     name: release linux/windows
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: wangyoucao577/go-release-action@v1.53
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: wangyoucao577/go-release-action@481a2c1a0f1be199722e3e9b74d7199acafc30a8 # v1.53
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goversion: "1.26"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o solaredge-exporter .
 
-FROM alpine:latest
+FROM alpine:3.22
 ENV INVERTER_ADDRESS=192.168.1.189
 ENV INVERTER_PORT=502
 ENV EXPORTER_INTERVAL=5
-RUN apk add --no-cache bash
-WORKDIR /root
+RUN apk add --no-cache bash && adduser -D solaredge
+# The home directory must stay writable: the default Log.Path is relative to
+# the working directory.
+WORKDIR /home/solaredge
 COPY --from=build /see-build/solaredge-exporter .
+USER solaredge
 CMD ["./solaredge-exporter"]

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -32,7 +32,9 @@ import (
 // read from) so multiple inverters can be polled by a single exporter.
 var labels = []string{"inverter"}
 
-func newGauge(name string, help string) *prometheus.GaugeVec {
+const scaleFactorHelp = "Scale factor"
+
+func newGauge(name, help string) *prometheus.GaugeVec {
 	return promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: name,
 		Help: help,
@@ -92,55 +94,55 @@ var (
 		"Hertz AC Frequency value")
 
 	AC_Frequency_SF = newGauge("AC_Frequency_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	AC_VA = newGauge("AC_VA",
 		"VA Apparent Power")
 
 	AC_VA_SF = newGauge("AC_VA_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	AC_VAR = newGauge("AC_VAR",
 		"VAR Reactive Power")
 
 	AC_VAR_SF = newGauge("AC_VAR_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	AC_PF = newGauge("AC_PF",
 		"% Power Factor")
 
 	AC_PF_SF = newGauge("AC_PF_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	AC_Energy_WH = newGauge("AC_Energy_WH",
 		"WattHours AC Lifetime Energy production")
 
 	AC_Energy_WH_SF = newGauge("AC_Energy_WH_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	DC_Current = newGauge("DC_Current",
 		"Amps DC Current value")
 
 	DC_Current_SF = newGauge("DC_Current_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	DC_Voltage = newGauge("DC_Voltage",
 		"Volts DC Voltage value")
 
 	DC_Voltage_SF = newGauge("DC_Voltage_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	DC_Power = newGauge("DC_Power",
 		"Watts DC Power value")
 
 	DC_Power_SF = newGauge("DC_Power_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	Temp_Sink = newGauge("Temp_Sink",
 		"Degrees C Heat Sink Temperature")
 
 	Temp_SF = newGauge("Temp_SF",
-		"Scale factor")
+		scaleFactorHelp)
 
 	Status = newGauge("Status",
 		"Operating State")
@@ -204,7 +206,7 @@ type MeterMetrics struct {
 // NewMeterMetrics registers and returns the gauge set for one meter, using
 // the given metric name prefix (e.g. "M" for meter 1, "M2" for meter 2).
 func NewMeterMetrics(prefix string) *MeterMetrics {
-	g := func(name string, help string) *prometheus.GaugeVec {
+	g := func(name, help string) *prometheus.GaugeVec {
 		return newGauge(prefix+"_"+name, help)
 	}
 
@@ -226,7 +228,7 @@ func NewMeterMetrics(prefix string) *MeterMetrics {
 		AC_VoltageCA:    g("AC_VoltageCA", "Volts AC Voltage Phase CA value"),
 		AC_Voltage_SF:   g("AC_Voltage_SF", "AC Voltage scale factor"),
 		AC_Frequency:    g("AC_Frequency", "Hertz AC Frequency value"),
-		AC_Frequency_SF: g("AC_Frequency_SF", "Scale factor"),
+		AC_Frequency_SF: g("AC_Frequency_SF", scaleFactorHelp),
 		AC_Power:        g("AC_Power", "Watts AC Power value"),
 		AC_Power_A:      g("AC_Power_A", "Watts AC Power value Phase A"),
 		AC_Power_B:      g("AC_Power_B", "Watts AC Power value Phase B"),
@@ -236,17 +238,17 @@ func NewMeterMetrics(prefix string) *MeterMetrics {
 		AC_VA_A:         g("AC_VA_A", "VA Apparent Power Phase A"),
 		AC_VA_B:         g("AC_VA_B", "VA Apparent Power Phase B"),
 		AC_VA_C:         g("AC_VA_C", "VA Apparent Power Phase C"),
-		AC_VA_SF:        g("AC_VA_SF", "Scale factor"),
+		AC_VA_SF:        g("AC_VA_SF", scaleFactorHelp),
 		AC_VAR:          g("AC_VAR", "VAR Reactive Power"),
 		AC_VAR_A:        g("AC_VAR_A", "VAR Reactive Power Phase A"),
 		AC_VAR_B:        g("AC_VAR_B", "VAR Reactive Power Phase B"),
 		AC_VAR_C:        g("AC_VAR_C", "VAR Reactive Power Phase C"),
-		AC_VAR_SF:       g("AC_VAR_SF", "Scale factor"),
+		AC_VAR_SF:       g("AC_VAR_SF", scaleFactorHelp),
 		AC_PF:           g("AC_PF", "% Power Factor"),
 		AC_PF_A:         g("AC_PF_A", "% Power Factor Phase A"),
 		AC_PF_B:         g("AC_PF_B", "% Power Factor Phase B"),
 		AC_PF_C:         g("AC_PF_C", "% Power Factor Phase C"),
-		AC_PF_SF:        g("AC_PF_SF", "Scale factor"),
+		AC_PF_SF:        g("AC_PF_SF", scaleFactorHelp),
 		Exported:        g("Exported", "WattHours AC Exported"),
 		Exported_A:      g("Exported_A", "WattHours AC Exported Phase A"),
 		Exported_B:      g("Exported_B", "WattHours AC Exported Phase B"),

--- a/main.go
+++ b/main.go
@@ -27,13 +27,18 @@ import (
 	"SolarEdge-Exporter/config"
 	"SolarEdge-Exporter/exporter"
 	"SolarEdge-Exporter/solaredge"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/goburrow/modbus"
@@ -91,18 +96,35 @@ func main() {
 		meterMetrics[i] = exporter.NewMeterMetrics(prefix)
 	}
 
-	// Start Data Collection for each configured inverter
-	// TODO: Add a cancellation context on SIGINT to cleanly close the connection
+	// Start Data Collection for each configured inverter. The context is
+	// cancelled on SIGINT/SIGTERM so the collectors close their connections
+	// cleanly before the process exits.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	var collectors sync.WaitGroup
 	for _, target := range inverterTargets() {
-		go runCollection(target, meterMetrics)
+		collectors.Add(1)
+		go func() {
+			defer collectors.Done()
+			runCollection(ctx, target, meterMetrics)
+		}()
 	}
 
-	// Start Prometheus Handler
+	// Start Prometheus Handler, shutting it down once a stop signal arrives
 	http.Handle("/metrics", promhttp.Handler())
-	err = http.ListenAndServe(viper.GetString("Exporter.ListenAddress")+":"+strconv.Itoa(viper.GetInt("Exporter.ListenPort")), nil)
-	if err != nil {
+	server := &http.Server{Addr: viper.GetString("Exporter.ListenAddress") + ":" + strconv.Itoa(viper.GetInt("Exporter.ListenPort"))}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	err = server.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Error().Msgf("Could not start the prometheus metric server: %s", err.Error())
 	}
+	collectors.Wait()
+	log.Info().Msg("SolarEdge-Exporter stopped")
 }
 
 // inverterTargets returns the list of inverter "host:port" targets from the
@@ -124,45 +146,26 @@ func inverterTargets() []string {
 	return targets
 }
 
-func runCollection(target string, meterMetrics []*exporter.MeterMetrics) {
+func runCollection(ctx context.Context, target string, meterMetrics []*exporter.MeterMetrics) {
 	// Get Interval from Config
-	interval := viper.GetInt("Exporter.Interval")
+	interval := time.Duration(viper.GetInt("Exporter.Interval")) * time.Second
 
-	// Configure Modbus Connection and Handler/Client
-	handler := modbus.NewTCPClientHandler(target)
-	handler.Timeout = 10 * time.Second
-	handler.SlaveId = byte(viper.GetInt("SolarEdge.ClientId"))
-	err := handler.Connect()
-	if err != nil {
-		log.Error().Msgf("[%s] Error connecting to Inverter: %s", target, err.Error())
-	}
-	client := modbus.NewClient(handler)
+	handler, client := connectInverter(target)
 	defer handler.Close()
-
-	// Collect and log common inverter data
-	infoData, err := client.ReadHoldingRegisters(40000, 70)
-	if err != nil {
-		log.Error().Msgf("[%s] Error reading inverter common block: %s", target, err.Error())
-	}
-	cm, err := solaredge.NewCommonModel(infoData)
-	if err != nil {
-		log.Error().Msgf("[%s] Error parsing inverter common block: %s", target, err.Error())
-	}
-	log.Info().Msgf("[%s] Inverter Model: %s", target, cm.C_Model)
-	log.Info().Msgf("[%s] Inverter Serial: %s", target, cm.C_SerialNumber)
-	log.Info().Msgf("[%s] Inverter Version: %s", target, cm.C_Version)
 
 	activeMeters := 0
 	metersDetected := false
 
-	// Collect logs forever
+	// Collect logs until the context is cancelled
 	for {
 		inverterData, err := client.ReadHoldingRegisters(40069, 40)
 		if err != nil {
 			log.Error().Msgf("[%s] Error reading holding registers: %s", target, err.Error())
 			log.Error().Msgf("[%s] Attempting to reconnect", target)
 			_ = handler.Close()
-			time.Sleep(7 * time.Second)
+			if !sleepOrDone(ctx, 7*time.Second) {
+				return
+			}
 			_ = handler.Connect()
 			continue
 		}
@@ -177,33 +180,77 @@ func runCollection(target string, meterMetrics []*exporter.MeterMetrics) {
 			activeMeters, metersDetected = detectMeters(client, target, len(meterMetrics))
 		}
 
-		for i := range activeMeters {
-			meterData, err := client.ReadHoldingRegisters(uint16(meterDataBase+i*meterBlockLength), 105)
-			if err != nil {
-				log.Error().Msgf("[%s] Error reading meter %d registers: %s", target, i+1, err.Error())
-				break
-			}
-			mt, err := solaredge.NewMeterModel(meterData)
-			if err != nil {
-				log.Error().Msgf("[%s] Error parsing meter %d data: %s", target, i+1, err.Error())
-				break
-			}
-			log.Debug().Msgf("[%s] Meter %d AC Current: %f", target, i+1, float64(mt.M_AC_Current)*math.Pow(10, float64(mt.M_AC_Current_SF)))
-			log.Debug().Msgf("[%s] Meter %d VoltageLN: %f", target, i+1, float64(mt.M_AC_VoltageLN)*math.Pow(10, float64(mt.M_AC_Voltage_SF)))
-			log.Debug().Msgf("[%s] Meter %d PF: %d", target, i+1, mt.M_AC_PF)
-			log.Debug().Msgf("[%s] Meter %d Freq: %f", target, i+1, float64(mt.M_AC_Frequency)*math.Pow(10, float64(mt.M_AC_Frequency_SF)))
-			log.Debug().Msgf("[%s] Meter %d AC Power: %f", target, i+1, float64(mt.M_AC_Power)*math.Pow(10.0, float64(mt.M_AC_Power_SF)))
-			log.Debug().Msgf("[%s] Meter %d M_AC_VA: %f", target, i+1, float64(mt.M_AC_VA)*math.Pow(10.0, float64(mt.M_AC_VA_SF)))
-			log.Debug().Msgf("[%s] Meter %d M_Exported: %f", target, i+1, float64(mt.M_Exported)*math.Pow(10.0, float64(mt.M_Energy_W_SF)))
-			log.Debug().Msgf("[%s] Meter %d M_Imported: %f", target, i+1, float64(mt.M_Imported)*math.Pow(10.0, float64(mt.M_Energy_W_SF)))
-			setMetricsForMeter(meterMetrics[i], mt, target)
-		}
+		collectMeters(client, target, activeMeters, meterMetrics)
 
 		log.Debug().Msg("-------------------------------------------")
 		log.Debug().Msgf("[%s] Data retrieved from inverter", target)
-		time.Sleep(time.Duration(interval) * time.Second)
+		if !sleepOrDone(ctx, interval) {
+			return
+		}
 	}
+}
 
+// connectInverter opens the modbus connection to the inverter and logs its
+// common block details. Connection errors are logged, not fatal: the read
+// loop re-establishes the connection on its next cycle.
+func connectInverter(target string) (*modbus.TCPClientHandler, modbus.Client) {
+	handler := modbus.NewTCPClientHandler(target)
+	handler.Timeout = 10 * time.Second
+	handler.SlaveId = byte(viper.GetInt("SolarEdge.ClientId"))
+	err := handler.Connect()
+	if err != nil {
+		log.Error().Msgf("[%s] Error connecting to Inverter: %s", target, err.Error())
+	}
+	client := modbus.NewClient(handler)
+
+	infoData, err := client.ReadHoldingRegisters(40000, 70)
+	if err != nil {
+		log.Error().Msgf("[%s] Error reading inverter common block: %s", target, err.Error())
+	}
+	cm, err := solaredge.NewCommonModel(infoData)
+	if err != nil {
+		log.Error().Msgf("[%s] Error parsing inverter common block: %s", target, err.Error())
+	}
+	log.Info().Msgf("[%s] Inverter Model: %s", target, cm.C_Model)
+	log.Info().Msgf("[%s] Inverter Serial: %s", target, cm.C_SerialNumber)
+	log.Info().Msgf("[%s] Inverter Version: %s", target, cm.C_Version)
+	return handler, client
+}
+
+// collectMeters reads and publishes the data block of each active meter.
+func collectMeters(client modbus.Client, target string, activeMeters int, meterMetrics []*exporter.MeterMetrics) {
+	for i := range activeMeters {
+		meterData, err := client.ReadHoldingRegisters(uint16(meterDataBase+i*meterBlockLength), 105)
+		if err != nil {
+			log.Error().Msgf("[%s] Error reading meter %d registers: %s", target, i+1, err.Error())
+			return
+		}
+		mt, err := solaredge.NewMeterModel(meterData)
+		if err != nil {
+			log.Error().Msgf("[%s] Error parsing meter %d data: %s", target, i+1, err.Error())
+			return
+		}
+		log.Debug().Msgf("[%s] Meter %d AC Current: %f", target, i+1, float64(mt.M_AC_Current)*math.Pow(10, float64(mt.M_AC_Current_SF)))
+		log.Debug().Msgf("[%s] Meter %d VoltageLN: %f", target, i+1, float64(mt.M_AC_VoltageLN)*math.Pow(10, float64(mt.M_AC_Voltage_SF)))
+		log.Debug().Msgf("[%s] Meter %d PF: %d", target, i+1, mt.M_AC_PF)
+		log.Debug().Msgf("[%s] Meter %d Freq: %f", target, i+1, float64(mt.M_AC_Frequency)*math.Pow(10, float64(mt.M_AC_Frequency_SF)))
+		log.Debug().Msgf("[%s] Meter %d AC Power: %f", target, i+1, float64(mt.M_AC_Power)*math.Pow(10.0, float64(mt.M_AC_Power_SF)))
+		log.Debug().Msgf("[%s] Meter %d M_AC_VA: %f", target, i+1, float64(mt.M_AC_VA)*math.Pow(10.0, float64(mt.M_AC_VA_SF)))
+		log.Debug().Msgf("[%s] Meter %d M_Exported: %f", target, i+1, float64(mt.M_Exported)*math.Pow(10.0, float64(mt.M_Energy_W_SF)))
+		log.Debug().Msgf("[%s] Meter %d M_Imported: %f", target, i+1, float64(mt.M_Imported)*math.Pow(10.0, float64(mt.M_Energy_W_SF)))
+		setMetricsForMeter(meterMetrics[i], mt, target)
+	}
+}
+
+// sleepOrDone waits for d and reports whether the wait completed; it returns
+// false when ctx is cancelled first.
+func sleepOrDone(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
 }
 
 // detectMeters probes which of the configured meters are actually present.


### PR DESCRIPTION
Fixes all 11 open SonarCloud issues on master.

## Changes

- **exporter/metrics.go**: Replace the "Scale factor" help string duplicated 13 times with a `scaleFactorHelp` constant (S1192); group consecutive same-type parameters (S8209 ×2).
- **main.go**: Reduce `runCollection` cognitive complexity from 18 to under 15 by extracting `connectInverter` and `collectMeters` (S3776). Resolve the shutdown TODO (S1135) by implementing it: a `signal.NotifyContext` on SIGINT/SIGTERM cancels the collectors (context-aware sleeps so deferred `handler.Close()` runs), gracefully shuts down the HTTP server, and waits for collectors before exit.
- **.github/workflows/release.yml**: Pin actions to full commit SHAs with version comments (S7637 ×4).
- **Dockerfile**: Pin `alpine:3.22` instead of `latest` (S6596) and run as a non-root `solaredge` user (S6471), with the workdir set to its home so the default relative log path stays writable.

## Verification

- `go build`, `go vet`, and `gofmt` clean
- SonarQube analyzer reports zero issues on the updated main.go and Dockerfile
- Ran the exporter end-to-end: serves `/metrics` (38 metric families) and exits cleanly (code 0) on SIGTERM, including mid-reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)